### PR TITLE
Move button for automatic wallpaper to start

### DIFF
--- a/resources/ui/application-window.blp
+++ b/resources/ui/application-window.blp
@@ -27,6 +27,18 @@ template $PotDApplicationWindow: Adw.ApplicationWindow {
       Box {
         orientation: horizontal;
 
+        ToggleButton {
+          icon-name: "today-symbolic";
+          tooltip-text: C_("main-window.toolbar.button.tooltip", "Set daily wallpaper automatically");
+          action-name: "win.set-wallpaper-automatically";
+        }
+
+        Separator {
+          styles [
+            "spacer",
+          ]
+        }
+
         MenuButton {
           label: C_("main-window.toolbar.button.label", "Source");
 
@@ -78,18 +90,6 @@ template $PotDApplicationWindow: Adw.ApplicationWindow {
           icon-name: "image-symbolic";
           action-name: "win.set-as-wallpaper";
           tooltip-text: C_("main-window.toolbar.button.tooltip", "Set current image as wallpaper");
-        }
-
-        Separator {
-          styles [
-            "spacer",
-          ]
-        }
-
-        ToggleButton {
-          icon-name: "today-symbolic";
-          tooltip-text: C_("main-window.toolbar.button.tooltip", "Set daily wallpaper automatically");
-          action-name: "win.set-wallpaper-automatically";
         }
 
         Separator {

--- a/resources/ui/application-window.ui
+++ b/resources/ui/application-window.ui
@@ -25,6 +25,20 @@ corresponding .blp file and regenerate this file with blueprint-compiler.
               <object class="GtkBox">
                 <property name="orientation">0</property>
                 <child>
+                  <object class="GtkToggleButton">
+                    <property name="icon-name">today-symbolic</property>
+                    <property name="tooltip-text" translatable="yes" context="main-window.toolbar.button.tooltip">Set daily wallpaper automatically</property>
+                    <property name="action-name">win.set-wallpaper-automatically</property>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkSeparator">
+                    <style>
+                      <class name="spacer"/>
+                    </style>
+                  </object>
+                </child>
+                <child>
                   <object class="GtkMenuButton">
                     <property name="label" translatable="yes" context="main-window.toolbar.button.label">Source</property>
                     <child>
@@ -83,20 +97,6 @@ corresponding .blp file and regenerate this file with blueprint-compiler.
                     <property name="icon-name">image-symbolic</property>
                     <property name="action-name">win.set-as-wallpaper</property>
                     <property name="tooltip-text" translatable="yes" context="main-window.toolbar.button.tooltip">Set current image as wallpaper</property>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkSeparator">
-                    <style>
-                      <class name="spacer"/>
-                    </style>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkToggleButton">
-                    <property name="icon-name">today-symbolic</property>
-                    <property name="tooltip-text" translatable="yes" context="main-window.toolbar.button.tooltip">Set daily wallpaper automatically</property>
-                    <property name="action-name">win.set-wallpaper-automatically</property>
                   </object>
                 </child>
                 <child>


### PR DESCRIPTION
Now, start has all buttons related to source and images in general, and end only has the menu and buttons for the currently visible image.
