### PR TITLE
Fix gettext initialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -748,6 +748,7 @@ dependencies = [
  "glob",
  "gtk4",
  "libadwaita",
+ "libc",
  "log",
  "rand",
  "rand_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ futures = "0.3.31"
 url = "2.5.4"
 rand = { version = "0.8.5", default-features = false, features = ["alloc"] }
 rand_core = "0.6.4"
+libc = "0.2.170"
 
 [build-dependencies]
 glob = "0.3.1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,6 @@
 
 use app::Application;
 use glib::dpgettext2;
-use glib::gstr;
 use gtk::gio;
 use gtk::prelude::*;
 
@@ -80,10 +79,9 @@ fn main() -> glib::ExitCode {
         "Initializing gettext with locale directory {}",
         locale_dir.display()
     );
-    gettext::bindtextdomain(config::APP_ID, locale_dir).unwrap();
-    gettext::textdomain(config::APP_ID).unwrap();
-    gettext::bind_textdomain_codeset(config::APP_ID, gstr!("UTF-8")).unwrap();
-    gettext::setlocale(gettext::LC_ALL, gstr!("")).unwrap();
+    if let Err(error) = gettext::init_gettext(config::APP_ID, locale_dir) {
+        glib::warn!("Failed to initialize gettext: {error}");
+    }
 
     gio::resources_register_include!("pictureoftheday.gresource").unwrap();
     glib::set_application_name(&dpgettext2(None, "application-name", "Picture Of The Day"));


### PR DESCRIPTION
We need to call setlocale first because gettext needs it, and we should not crash on errors, since gettext errors aren't fatal; worst case we'll just fall back to untranslated strings.

We also use libc for setlocale and LC_ALL now; we have it in our tree anyway, so there's no pointing in re-doing these definitions.

Closes GH-51