### PR TITLE
Properly cleanup partial downloads

### DIFF
--- a/resources/de.swsnr.pictureoftheday.metainfo.xml.in
+++ b/resources/de.swsnr.pictureoftheday.metainfo.xml.in
@@ -47,11 +47,13 @@
             <description>
                 <p>Add overlay toolbar to go to the previous or next image to the image view.</p>
                 <p>Add toolbar buttons to save the current image, and to open the current image in an external application.</p>
+                <p>Try harder not to leave partially downloaded wallpapers behind when quitting.</p>
             </description>
             <issues>
                 <issue url="https://github.com/swsnr/picture-of-the-day/issues/15">GH-15</issue>
                 <issue url="https://github.com/swsnr/picture-of-the-day/issues/16">GH-16</issue>
                 <issue url="https://github.com/swsnr/picture-of-the-day/issues/18">GH-18</issue>
+                <issue url="https://github.com/swsnr/picture-of-the-day/issues/50">GH-50</issue>
             </issues>
             <url>https://github.com/swsnr/picture-of-the-day/releases/tag/next</url>
         </release>

--- a/src/app.rs
+++ b/src/app.rs
@@ -273,7 +273,7 @@ impl Application {
         let image = images.choose(&mut GlibRng).unwrap();
 
         let target_directory = source.images_directory();
-        ensure_directory(&target_directory, cancellable).await?;
+        ensure_directory(&target_directory).await?;
         let target = image
             .download_to_directory(&target_directory, &session, cancellable)
             .await?;

--- a/src/app/model/error_notification.rs
+++ b/src/app/model/error_notification.rs
@@ -131,19 +131,6 @@ mod errors {
             .build()
     }
 
-    pub fn cancelled(source: Source) -> ErrorNotification {
-        let title = dpgettext2(None, "error-notification.title", "Cancelled");
-        let description = dpgettext2(
-            None,
-            "error-notification.description",
-            "You cancelled loading images from %1.",
-        );
-        ErrorNotification::builder()
-            .title(title)
-            .description(description.replace("%1", &source.i18n_name()))
-            .build()
-    }
-
     pub fn io_error(source: Source, error: &glib::Error) -> ErrorNotification {
         let connectivity = gio::NetworkMonitor::default().connectivity();
         let (title, description) = if connectivity == gio::NetworkConnectivity::Full {
@@ -192,7 +179,6 @@ impl ErrorNotification {
             SourceError::HttpStatus(status, _) => errors::http_status(source, *status),
             SourceError::InvalidJson(_) => errors::invalid_data(source),
             SourceError::IO(error) => errors::io_error(source, error),
-            SourceError::Cancelled => errors::cancelled(source),
         }
     }
 }

--- a/src/app/widgets/application_window.rs
+++ b/src/app/widgets/application_window.rs
@@ -300,6 +300,7 @@ mod imp {
 
         pub fn cancel_loading(&self) {
             if let Some(cancellable) = self.is_loading.replace(None) {
+                glib::debug!("Cancelling image loading in window");
                 cancellable.cancel();
                 self.obj().notify_is_loading();
             }
@@ -608,7 +609,15 @@ mod imp {
 
     impl ApplicationWindowImpl for ApplicationWindow {}
 
-    impl WindowImpl for ApplicationWindow {}
+    impl WindowImpl for ApplicationWindow {
+        fn close_request(&self) -> glib::Propagation {
+            let result = self.parent_close_request();
+            if result.is_proceed() {
+                self.cancel_loading();
+            }
+            result
+        }
+    }
 
     impl WidgetImpl for ApplicationWindow {}
 }

--- a/src/app/widgets/application_window.rs
+++ b/src/app/widgets/application_window.rs
@@ -407,7 +407,7 @@ mod imp {
 
             // Create the download directory for the current source.
             let target_directory = source.images_directory();
-            ensure_directory(&target_directory, cancellable).await?;
+            ensure_directory(&target_directory).await?;
 
             // Download all images
             let http_session = self.http_session.borrow().clone();

--- a/src/app/widgets/application_window.rs
+++ b/src/app/widgets/application_window.rs
@@ -326,7 +326,9 @@ mod imp {
 
         pub fn start_loading(&self) -> gio::Cancellable {
             let cancellable = gio::Cancellable::new();
-            self.is_loading.replace(Some(cancellable.clone()));
+            if let Some(old_cancellable) = self.is_loading.replace(Some(cancellable.clone())) {
+                old_cancellable.cancel();
+            }
             self.obj().notify_is_loading();
             cancellable
         }


### PR DESCRIPTION
Wrap temporary files for downloads in a struct with a drop impl to scope the lifetime of our temp files.

Use gio futures and proper gio futures for all async code.

Together this enables us to stop passing down cancellables all over the place, and instead rely on drop and top-level cancellable futures to handle cancellation, which is simpler and more reliably cleans up.

Then profit from this refactoring: Cleanly cancel image loading when closing the main window, deleting partial downloads.  When quitting, do not quit hard; instead close the active window and cancel automatic wallpaper updates (again, deleting partial downloads), which causes all app holds to drop. The app then quits automatically, after all cleanup is done.

Closes GH-50.
