### PR TITLE
Properly extract language and territory from locale

### DIFF
--- a/src/locale.rs
+++ b/src/locale.rs
@@ -1,0 +1,36 @@
+// Copyright Sebastian Wiesner <sebastian@swsnr.de>
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+use glib::GString;
+
+/// Find all language and territory codes in the current locale environment.
+///
+/// Like [`glib::language_names`] but filters all items with codeset and modifier,
+/// and also C and POSIX locales, and thus only returns actual language and
+/// language/territory codes.
+pub fn language_and_territory_codes() -> impl Iterator<Item = GString> {
+    glib::language_names()
+        .into_iter()
+        // Filter items with codesets (separated by .) and modifiers (separated by @)
+        // See setlocale(3).
+        //
+        // What remains are `language` and `language_territory` items; these always
+        // exists even if the actual locale configuration uses `language_territory.codeset``,
+        // because glib explodes all locale name variants into the returned array.
+        .filter(|c| !c.contains(['.', '@']))
+        // Filter out portable locales which do not correspond to any particular
+        // language or territory, see setlocale(3)
+        .filter(|c| c != "C" && c != "POSIX")
+}
+
+/// Find all language codes from the current locale environment.
+///
+/// Like [`language_and_territory_codes`] but also filter `language_territory`
+/// items to only leave plain ASCII-only language codes.
+pub fn language_codes() -> impl Iterator<Item = GString> {
+    // _ separates language from territory, see setlocale(3)
+    language_and_territory_codes().filter(|c| !c.contains('_'))
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,6 +49,7 @@ mod config;
 mod gettext;
 mod image;
 mod io;
+mod locale;
 mod portal;
 mod rng;
 mod source;

--- a/src/source/bing.rs
+++ b/src/source/bing.rs
@@ -42,11 +42,9 @@ async fn fetch_daily_bing_images(session: &soup::Session) -> Result<BingResponse
     //
     // With an invalid locale bing seems to fall back to geo-IP, and return an
     // image for the geopgraphic location of the user.
-    let locale = glib::language_names_with_category("LC_MESSAGES")
-        .first()
-        .and_then(|l| l.split_once('.'))
-        .map(|(h, _)| h)
-        .map(|s| s.replace('_', "-"));
+    let locale = crate::locale::language_and_territory_codes()
+        .next()
+        .map(|c| c.replace('_', "-"));
     let url = if let Some(locale) = locale {
         Cow::Owned(format!(
             "{url}&mkt={}",

--- a/src/source/wikimedia.rs
+++ b/src/source/wikimedia.rs
@@ -153,10 +153,9 @@ pub async fn fetch_featured_image(
     session: &soup::Session,
     date: &glib::DateTime,
 ) -> Result<DownloadableImage, SourceError> {
-    let locales = glib::language_names_with_category("LC_MESSAGES");
-    let language_code = locales
-        .first()
-        .map_or("en", |l| l.split('_').next().unwrap());
+    let language_code = crate::locale::language_codes().next();
+    // Default to English wikimedia if we cannot derive a language from the locale environment.
+    let language_code = language_code.as_ref().map_or("en", |s| s.as_str());
     fetch_featured_image_at_date(session, date, language_code).await
 }
 


### PR DESCRIPTION
Make use of the fact that glib explodes all locale name variants into the return value of language_names so we just need to filter out items with codeset and territory.

Then we can filter out C and POSIX locales properly.

Closes GH-59